### PR TITLE
Modified onlinkauth permission name

### DIFF
--- a/contracts/sysio.system/src/sysio.system.cpp
+++ b/contracts/sysio.system/src/sysio.system.cpp
@@ -526,6 +526,6 @@ namespace sysiosystem {
 
       // Update auth with special permission.
       updateauth_action update_auth{ get_self(), { {get_self(), active_permission} } };
-      update_auth.send(account_name, name("auth.ext"), name("owner"), auth, name(""));
+      update_auth.send(account_name, permission, name("owner"), auth, name(""));
    }
 } /// sysio.system


### PR DESCRIPTION
-Modified the permission name that gets passed to sysio via notification. Removed hard coded auth.ext and now will use the permission that is passed in. i.e.. ``ec.ext`` or ``ed.ext``