### PR TITLE
Minor patch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What does this Pull Request do?
+
+*
+
+### Why is this Pull Request needed?
+
+*
+
+### Are there any points in the code that the reviewer needs to double-check?
+
+### Are there any Pull Requests open in other repos that need to be merged with this?

--- a/contracts/sysio.roa/src/sysio.roa.cpp
+++ b/contracts/sysio.roa/src/sysio.roa.cpp
@@ -182,6 +182,8 @@ namespace sysio {
             row.allocated_bw.amount += (netWeight.amount + cpuWeight.amount);
             row.allocated_ram.amount += ramWeight.amount;
         });
+
+        require_recipient(owner); // Notify the owner of the new policy
     };
 
     void roa::expandpolicy(const name& owner, const name& issuer, const asset& netWeight, const asset& cpuWeight, const asset& ramWeight, const uint8_t& networkGen) {
@@ -259,6 +261,8 @@ namespace sysio {
         } else {
             set_resource_limits(owner, updated_res_itr->ram_bytes, updated_res_itr->net_weight.amount, updated_res_itr->cpu_weight.amount);
         }
+
+        require_recipient(owner); // Notify the owner of the policy expansion
     };
 
     void roa::extendpolicy(const name& owner, const name& issuer, const uint32_t& newTimeBlock) {
@@ -275,6 +279,8 @@ namespace sysio {
         policies.modify(pol_itr, get_self(), [&](auto& row) {
             row.time_block = newTimeBlock;
         });
+
+        require_recipient(owner); // Notify the owner of the policy extension
     };
     
     void roa::reducepolicy(const name& owner, const name& issuer, const asset& net_weight, const asset& cpu_weight, const asset& ram_weight, const uint8_t& network_gen) { 
@@ -509,6 +515,8 @@ namespace sysio {
             row.network_gen = state.network_gen;
         });
 
+        require_recipient(owner); // Notify the owner of the new registration
+        
         // TODO: Notify Council contract if needed
     };
 

--- a/contracts/sysio.system/src/voting.cpp
+++ b/contracts/sysio.system/src/voting.cpp
@@ -38,7 +38,7 @@ namespace sysiosystem {
       }, producer_authority );
 
       if ( prod != _producers.end() ) {
-         _producers.modify( prod, producer, [&]( producer_info& info ){
+         _producers.modify( prod, get_self(), [&]( producer_info& info ){
             info.producer_key       = producer_key;
             info.is_active          = true;
             info.url                = url;
@@ -50,7 +50,7 @@ namespace sysiosystem {
 
          auto prod2 = _producers2.find( producer.value );
          if ( prod2 == _producers2.end() ) {
-            _producers2.emplace( producer, [&]( producer_info2& info ){
+            _producers2.emplace( get_self(), [&]( producer_info2& info ){
                info.owner                     = producer;
                info.last_votepay_share_update = ct;
             });
@@ -58,7 +58,7 @@ namespace sysiosystem {
             // When introducing the producer2 table row for the first time, the producer's votes must also be accounted for in the global total_producer_votepay_share at the same time.
          }
       } else {
-         _producers.emplace( producer, [&]( producer_info& info ){
+         _producers.emplace( get_self(), [&]( producer_info& info ){
             info.owner              = producer;
             info.total_votes        = 0;
             info.producer_key       = producer_key;
@@ -68,7 +68,7 @@ namespace sysiosystem {
             info.last_claim_time    = ct;
             info.producer_authority.emplace( producer_authority );
          });
-         _producers2.emplace( producer, [&]( producer_info2& info ){
+         _producers2.emplace( get_self(), [&]( producer_info2& info ){
             info.owner                     = producer;
             info.last_votepay_share_update = ct;
          });


### PR DESCRIPTION
### What does this Pull Request do?

Change Type: Other
* Adds notifications when a ROA policy is added, expanded, or extended. Receiver of the notification is the account that the policy was allocated to.

* Adjusted register_producer to make sysio pay for Node Operator registrations.

### Why is this Pull Request needed?

* For policy notifications, Josh requested this to better make policy holders aware of changes and improve UI.

* For register_producer with the previous PR which fixed our resource charging structure certain system actions will need to be adjusted like this to allow for ease of use of our network.

### Are there any points in the code that the reviewer needs to double-check?

* No

### Are there any Pull Requests open in other repos that need to be merged with this?

* No