### PR TITLE
ROA Cleanup testing artifact

### DIFF
--- a/contracts/sysio.roa/src/sysio.roa.cpp
+++ b/contracts/sysio.roa/src/sysio.roa.cpp
@@ -64,12 +64,12 @@ namespace sysio {
         check(sysioreslimit.find(sys_account.value) == sysioreslimit.end(), "sysio reslimit already exists.");
         sysioreslimit.emplace(get_self(), [&](auto& row) {
             row.owner = sys_account;
-            row.net_weight = asset(56671995, totalSys.symbol);
-            row.cpu_weight = asset(56671995, totalSys.symbol);
+            row.net_weight = asset(0, totalSys.symbol);
+            row.cpu_weight = asset(0, totalSys.symbol);
             row.ram_bytes = sysio_ram_bytes;
         });
 
-        // Set sysio.roas new account limits.
+        // Set sysio new account limits.
         set_resource_limits(sys_account, sysio_ram_bytes, -1, -1);
     };
 


### PR DESCRIPTION
### What does this Pull Request do?

* Fixes a value set in sysio's reslimit table when calling 'activateroa'. When I was initially testing ROA in an attempt to get naturally changing schedules. set_resource_limits was defined correctly as -1 -1 for NET and CPU but I left huge incorrect values in sysio's reslimit table.
 
### Why is this Pull Request needed?

* Fixes a misalignment in sysio's reslimit table vs its actual CPU / NET values.

### Are there any points in the code that the reviewer needs to double-check?

### Are there any Pull Requests open in other repos that need to be merged with this?