### PR TITLE
Remove canceldelay and onerror

### DIFF
--- a/contracts/sysio.bios/include/sysio.bios/sysio.bios.hpp
+++ b/contracts/sysio.bios/include/sysio.bios/sysio.bios.hpp
@@ -69,7 +69,7 @@ namespace sysiobios {
    /**
     * The `sysio.bios` is the first sample of system contract provided by `block.one` through the SYSIO platform. It is a minimalist system contract because it only supplies the actions that are absolutely critical to bootstrap a chain and nothing more. This allows for a chain agnostic approach to bootstrapping a chain.
     * 
-    * Just like in the `sysio.system` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `sysio.system` contract, but the implementation is at the SYSIO core level. They are referred to as SYSIO native actions.
+    * Just like in the `sysio.system` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `sysio.system` contract, but the implementation is at the SYSIO core level. They are referred to as SYSIO native actions.
     */
    class [[sysio::contract("sysio.bios")]] bios : public sysio::contract {
       public:
@@ -117,7 +117,7 @@ namespace sysiobios {
 
          /**
           * Link authorization action assigns a specific action from a contract to a permission you have created. Five system
-          * actions can not be linked `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, and `canceldelay`.
+          * actions can not be linked `updateauth`, `deleteauth`, `linkauth`, and `unlinkauth`.
           * This is useful because when doing authorization checks, the SYSIO based blockchain starts with the
           * action needed to be authorized (and the contract belonging to), and looks up which permission
           * is needed to pass authorization validation. If a link is set, that permission is used for authoraization
@@ -149,15 +149,6 @@ namespace sysiobios {
                           ignore<name>  type ) {}
 
          /**
-          * Cancel delay action cancels a deferred transaction.
-          *
-          * @param canceling_auth - the permission that authorizes this action,
-          * @param trx_id - the deferred transaction id to be cancelled.
-          */
-         [[sysio::action]]
-         void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
-
-         /**
           * Set code action sets the contract code for an account.
           *
           * @param account - the account for which to set the contract code.
@@ -178,17 +169,6 @@ namespace sysiobios {
           */
          [[sysio::action]]
          void setabi( name account, const std::vector<char>& abi );
-
-         /**
-          * On error action, notification of this action is delivered to the sender of a deferred transaction
-          * when an objective error occurs while executing the deferred transaction.
-          * This action is not meant to be called directly.
-          *
-          * @param sender_id - the id for the deferred transaction chosen by the sender,
-          * @param sent_trx - the deferred transaction that failed.
-          */
-         [[sysio::action]]
-         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx );
 
          /**
           * Set privilege action allows to set privilege status for an account (turn it on/off).
@@ -268,7 +248,6 @@ namespace sysiobios {
          using deleteauth_action = action_wrapper<"deleteauth"_n, &bios::deleteauth>;
          using linkauth_action = action_wrapper<"linkauth"_n, &bios::linkauth>;
          using unlinkauth_action = action_wrapper<"unlinkauth"_n, &bios::unlinkauth>;
-         using canceldelay_action = action_wrapper<"canceldelay"_n, &bios::canceldelay>;
          using setcode_action = action_wrapper<"setcode"_n, &bios::setcode>;
          using setabi_action = action_wrapper<"setabi"_n, &bios::setabi>;
          using setpriv_action = action_wrapper<"setpriv"_n, &bios::setpriv>;

--- a/contracts/sysio.bios/src/sysio.bios.cpp
+++ b/contracts/sysio.bios/src/sysio.bios.cpp
@@ -17,10 +17,6 @@ void bios::setabi( name account, const std::vector<char>& abi ) {
    }
 }
 
-void bios::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {
-   check( false, "the onerror action cannot be called directly" );
-}
-
 void bios::setpriv( name account, uint8_t is_priv ) {
    require_auth( get_self() );
    set_privileged( account, is_priv );

--- a/contracts/sysio.boot/include/sysio.boot/sysio.boot.hpp
+++ b/contracts/sysio.boot/include/sysio.boot/sysio.boot.hpp
@@ -176,17 +176,6 @@ namespace sysioboot {
                           ignore<name>  type ) {}
 
          /**
-          * Cancel delay action.
-          *
-          * @details Cancels a deferred transaction.
-          *
-          * @param canceling_auth - the permission that authorizes this action,
-          * @param trx_id - the deferred transaction id to be cancelled.
-          */
-         [[sysio::action]]
-         void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
-
-         /**
           * Set code action.
           *
           * @details Sets the contract code for an account.
@@ -213,19 +202,6 @@ namespace sysioboot {
          /** @}*/
 
          /**
-          * On error action.
-          *
-          * @details Notification of this action is delivered to the sender of a deferred transaction
-          * when an objective error occurs while executing the deferred transaction.
-          * This action is not meant to be called directly.
-          *
-          * @param sender_id - the id for the deferred transaction chosen by the sender,
-          * @param sent_trx - the deferred transaction that failed.
-          */
-         [[sysio::action]]
-         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx );
-
-         /**
           * Activates a protocol feature.
           *
           * @details Activates a protocol feature
@@ -250,7 +226,6 @@ namespace sysioboot {
          using deleteauth_action = action_wrapper<"deleteauth"_n, &boot::deleteauth>;
          using linkauth_action = action_wrapper<"linkauth"_n, &boot::linkauth>;
          using unlinkauth_action = action_wrapper<"unlinkauth"_n, &boot::unlinkauth>;
-         using canceldelay_action = action_wrapper<"canceldelay"_n, &boot::canceldelay>;
          using setcode_action = action_wrapper<"setcode"_n, &boot::setcode>;
          using setabi_action = action_wrapper<"setabi"_n, &boot::setabi>;
          using activate_action = action_wrapper<"activate"_n, &boot::activate>;

--- a/contracts/sysio.boot/src/sysio.boot.cpp
+++ b/contracts/sysio.boot/src/sysio.boot.cpp
@@ -3,10 +3,6 @@
 
 namespace sysioboot {
 
-void boot::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {
-   check( false, "the onerror action cannot be called directly" );
-}
-
 void boot::activate( const sysio::checksum256& feature_digest ) {
    require_auth( get_self() );
    sysio::preactivate_feature( feature_digest );

--- a/contracts/sysio.system/include/sysio.system/native.hpp
+++ b/contracts/sysio.system/include/sysio.system/native.hpp
@@ -267,26 +267,6 @@ namespace sysiosystem {
          }
 
          /**
-          * Cancel delay action cancels a deferred transaction.
-          *
-          * @param canceling_auth - the permission that authorizes this action,
-          * @param trx_id - the deferred transaction id to be cancelled.
-          */
-         [[sysio::action]]
-         void canceldelay( ignore<permission_level> canceling_auth, ignore<checksum256> trx_id ) {}
-
-         /**
-          * On error action, notification of this action is delivered to the sender of a deferred transaction
-          * when an objective error occurs while executing the deferred transaction.
-          * This action is not meant to be called directly.
-          *
-          * @param sender_id - the id for the deferred transaction chosen by the sender,
-          * @param sent_trx - the deferred transaction that failed.
-          */
-         [[sysio::action]]
-         void onerror( ignore<uint128_t> sender_id, ignore<std::vector<char>> sent_trx );
-
-         /**
           * Set abi action sets the contract abi for an account.
           *
           * @param account - the account for which to set the contract abi.
@@ -314,7 +294,6 @@ namespace sysiosystem {
          using deleteauth_action = sysio::action_wrapper<"deleteauth"_n, &native::deleteauth>;
          using linkauth_action = sysio::action_wrapper<"linkauth"_n, &native::linkauth>;
          using unlinkauth_action = sysio::action_wrapper<"unlinkauth"_n, &native::unlinkauth>;
-         using canceldelay_action = sysio::action_wrapper<"canceldelay"_n, &native::canceldelay>;
          using setcode_action = sysio::action_wrapper<"setcode"_n, &native::setcode>;
          using setabi_action = sysio::action_wrapper<"setabi"_n, &native::setabi>;
    };

--- a/contracts/sysio.system/include/sysio.system/sysio.system.hpp
+++ b/contracts/sysio.system/include/sysio.system/sysio.system.hpp
@@ -74,7 +74,7 @@ namespace sysiosystem {
   /**
    * The `sysio.system` smart contract; it defines the structures and actions needed for blockchain's core functionality.
    * 
-   * Just like in the `sysio.bios` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `sysio.system` contract, but the implementation is at the SYSIO core level. They are referred to as SYSIO native actions.
+   * Just like in the `sysio.bios` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `sysio.system` contract, but the implementation is at the SYSIO core level. They are referred to as SYSIO native actions.
    * 
    * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
    *    delegate their vote to a proxy.
@@ -137,7 +137,7 @@ namespace sysiosystem {
    /**
     * The `sysio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the structures and actions needed for blockchain's core functionality.
     *
-    * Just like in the `sysio.bios` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `sysio.system` contract, but the implementation is at the SYSIO core level. They are referred to as SYSIO native actions.
+    * Just like in the `sysio.bios` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `sysio.system` contract, but the implementation is at the SYSIO core level. They are referred to as SYSIO native actions.
     *
     * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
     *    delegate their vote to a proxy.

--- a/contracts/sysio.system/src/native.cpp
+++ b/contracts/sysio.system/src/native.cpp
@@ -1,11 +1,5 @@
 #include <sysio.system/native.hpp>
 
-#include <sysio/check.hpp>
-
 namespace sysiosystem {
-
-   void native::onerror( ignore<uint128_t>, ignore<std::vector<char>> ) {
-      sysio::check( false, "the onerror action cannot be called directly" );
-   }
 
 }

--- a/tests/sysio.limitauth_tests.cpp
+++ b/tests/sysio.limitauth_tests.cpp
@@ -52,7 +52,7 @@ struct limitauth_tester: sysio_system_tester {
          signed_transaction trx;
          trx.actions.push_back(action{{pl}, code, act, std::move(vec)});
 
-         set_transaction_headers(trx, DEFAULT_EXPIRATION_DELTA, 0);
+         set_transaction_headers(trx, DEFAULT_EXPIRATION_DELTA);
          trx.sign(get_private_key(pl.actor, pl.permission.to_string()), control->get_chain_id());
          push_transaction(trx);
          return "";


### PR DESCRIPTION
### What does this Pull Request do?

* Remove `canceldelay` native action
* Remove `onerror` notify

### Why is this Pull Request needed?

* Wire-sysio does not support deferred transactions so these are not needed

### Are there any points in the code that the reviewer needs to double-check?

### Are there any Pull Requests open in other repos that need to be merged with this?